### PR TITLE
fix(draw): deadlock dma2d draw unit

### DIFF
--- a/src/draw/dma2d/lv_draw_dma2d.c
+++ b/src/draw/dma2d/lv_draw_dma2d.c
@@ -438,7 +438,7 @@ static void thread_cb(void * arg)
 
         do {
             lv_thread_sync_wait(&u->interrupt_signal);
-        } while(u->task_act != NULL);
+        } while(u->task_act == NULL);
 
         post_transfer_tasks(u);
         lv_draw_dispatch_request();


### PR DESCRIPTION
Thread is dealocked after first dma2d transfer is completeted, as thread gets woken up but task_act is still not NULL, so it calls sync_wait again and is blocked forever.
